### PR TITLE
Attempting to fix the issue around timestamp errors

### DIFF
--- a/test/UniswapV3Staker.unit.spec.ts
+++ b/test/UniswapV3Staker.unit.spec.ts
@@ -212,7 +212,7 @@ describe('UniswapV3Staker.unit', async () => {
       it('emits IncentiveEnded event', async () => {
         await createIncentive()
         // Adjust the block.timestamp so it is after the claim deadline
-        await ethers.provider.send('evm_setNextBlockTimestamp', [
+        await waffle.provider.send('evm_setNextBlockTimestamp', [
           claimDeadline + 1,
         ])
 
@@ -238,7 +238,7 @@ describe('UniswapV3Staker.unit', async () => {
         expect((await staker.incentives(incentiveId)).rewardToken).to.eq(
           tokens[0].address
         )
-        await ethers.provider.send('evm_setNextBlockTimestamp', [
+        await waffle.provider.send('evm_setNextBlockTimestamp', [
           claimDeadline + 1,
         ])
 
@@ -250,7 +250,7 @@ describe('UniswapV3Staker.unit', async () => {
 
       it('has gas cost', async () => {
         await createIncentive()
-        await ethers.provider.send('evm_setNextBlockTimestamp', [
+        await waffle.provider.send('evm_setNextBlockTimestamp', [
           claimDeadline + 1,
         ])
         await snapshotGasCost(subject())
@@ -262,7 +262,7 @@ describe('UniswapV3Staker.unit', async () => {
         await createIncentive()
 
         // Adjust the block.timestamp so it is before the claim deadline
-        await ethers.provider.send('evm_setNextBlockTimestamp', [
+        await waffle.provider.send('evm_setNextBlockTimestamp', [
           claimDeadline - 1,
         ])
 
@@ -273,7 +273,7 @@ describe('UniswapV3Staker.unit', async () => {
 
       it('incentive does not exist', async () => {
         // Adjust the block.timestamp so it is after the claim deadline
-        await ethers.provider.send('evm_setNextBlockTimestamp', [
+        await waffle.provider.send('evm_setNextBlockTimestamp', [
           claimDeadline + 1,
         ])
 

--- a/test/UniswapV3Staker.unit.spec.ts
+++ b/test/UniswapV3Staker.unit.spec.ts
@@ -363,8 +363,8 @@ describe('UniswapV3Staker.unit', async () => {
       await nft.approve(staker.address, tokenId, { gasLimit: 12450000 })
 
       await staker.depositToken(tokenId)
-      subject = async ({ tokenId, recipient }) =>
-        await staker.withdrawToken(tokenId, recipient)
+      subject = ({ tokenId, recipient }) =>
+        staker.withdrawToken(tokenId, recipient)
     })
 
     describe('works and', () => {
@@ -386,13 +386,13 @@ describe('UniswapV3Staker.unit', async () => {
       })
 
       it('has gas cost', async () => {
-        await snapshotGasCost(subject({tokenId, recipient}))
+        await snapshotGasCost(subject({ tokenId, recipient }))
       })
     })
 
     describe('fails if', () => {
       it('you are withdrawing a token that is not yours', async () => {
-        expect(
+        await expect(
           staker.connect(other).withdrawToken(tokenId, wallet.address)
         ).to.revertedWith('NOT_YOUR_NFT')
       })
@@ -416,7 +416,7 @@ describe('UniswapV3Staker.unit', async () => {
           endTime: 20,
           claimDeadline: 30,
         })
-        expect(subject({ tokenId, recipient })).to.revertedWith(
+        await expect(subject({ tokenId, recipient })).to.revertedWith(
           'NUMBER_OF_STAKES_NOT_ZERO'
         )
       })
@@ -474,8 +474,8 @@ describe('UniswapV3Staker.unit', async () => {
         claimDeadline,
       })
 
-      subject = async () =>
-        await staker.stakeToken({
+      subject = () =>
+        staker.stakeToken({
           creator,
           rewardToken: rewardToken.address,
           tokenId,
@@ -594,8 +594,8 @@ describe('UniswapV3Staker.unit', async () => {
         claimDeadline,
       })
 
-      subject = async ({ to }) => {
-        const params = {
+      subject = ({ to }) =>
+        staker.unstakeToken({
           creator,
           rewardToken: rewardToken.address,
           tokenId,
@@ -603,9 +603,7 @@ describe('UniswapV3Staker.unit', async () => {
           endTime,
           claimDeadline,
           to,
-        }
-        return await staker.unstakeToken(params)
-      }
+        })
     })
 
     const recipient = wallets[3].address

--- a/test/shared/index.ts
+++ b/test/shared/index.ts
@@ -9,10 +9,12 @@ import { TransactionReceipt, TransactionResponse } from '@ethersproject/abstract
 import { constants } from 'ethers'
 export const { MaxUint256 } = constants
 
-import { ethers } from 'hardhat'
+import { ethers, waffle } from 'hardhat'
 export const blockTimestamp = async () => {
-  const blockNumber = await ethers.provider.getBlockNumber()
-  const block = await ethers.provider.getBlock(blockNumber)
+  const block = await waffle.provider.getBlock('latest')
+  if (!block) {
+    throw new Error('null block returned from provider')
+  }
   return block.timestamp
 }
 


### PR DESCRIPTION
I did 3 things here in separate commits.

Cleaned up some async/awaits around when they weren't needed (as in the case of immediate return) and when there were missing awaits on async matchers.

Moved all provider calls to waffle.provider

Finally, moved getBlock(number) to getBlock('latest')

Since it's intermittent I'm not 100% sure it will actually fix things, but these are all at least forward progress.