### PR TITLE
Cleanup: give events more information + delete deposit on withdraw

### DIFF
--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -195,6 +195,7 @@ contract UniswapV3Staker is
         require(deposit.numberOfStakes == 0, 'nonzero num of stakes');
         require(deposit.owner == msg.sender, 'sender is not nft owner');
 
+        delete deposits[tokenId];
         nonfungiblePositionManager.safeTransferFrom(address(this), to, tokenId);
         emit TokenWithdrawn(tokenId, to);
     }

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -109,6 +109,7 @@ contract UniswapV3Staker is
         incentives[key] = Incentive(params.totalReward, 0, params.rewardToken);
 
         emit IncentiveCreated(
+            msg.sender,
             params.rewardToken,
             params.pool,
             params.startTime,
@@ -149,6 +150,7 @@ contract UniswapV3Staker is
         );
 
         emit IncentiveEnded(
+            msg.sender,
             params.rewardToken,
             params.pool,
             params.startTime,

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -154,7 +154,8 @@ contract UniswapV3Staker is
             params.rewardToken,
             params.pool,
             params.startTime,
-            params.endTime
+            params.endTime,
+            params.claimDeadline
         );
     }
 

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -313,8 +313,8 @@ contract UniswapV3Staker is
     }
 
     function _stakeToken(StakeTokenParams memory params) internal {
-      require(params.startTime <= block.timestamp, 'incentive not started');
-      require(params.endTime > block.timestamp, 'incentive ended');
+        require(params.startTime <= block.timestamp, 'incentive not started');
+        require(params.endTime > block.timestamp, 'incentive ended');
 
         (address poolAddress, int24 tickLower, int24 tickUpper, ) =
             _getPositionDetails(params.tokenId);

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -4,6 +4,7 @@ pragma abicoder v2;
 
 interface IUniswapV3Staker {
     /// @notice Event emitted when a liquidity mining incentive has been created
+    /// @param creator The address that created this incentive
     /// @param rewardToken The address of the token being distributed as a reward
     /// @param pool The address of the Uniswap V3 pool
     /// @param endTime The time when rewards stop accruing
@@ -20,16 +21,19 @@ interface IUniswapV3Staker {
     );
 
     /// @notice Event emitted when a liquidity mining incentive has ended
+    /// @param creator The address that created this incentive
     /// @param rewardToken The address of the token being distributed as a reward
     /// @param pool The address of the Uniswap V3 pool
     /// @param startTime The time when the incentive program begins
     /// @param endTime The time when rewards stop accruing
+    /// @param claimDeadline Time after which LPs can no longer claim rewards (and incentiveCreator can end the incentive and receive unclaimed rewards)
     event IncentiveEnded(
         address creator,
         address indexed rewardToken,
         address indexed pool,
         uint32 startTime,
-        uint32 endTime
+        uint32 endTime,
+        uint43 claimDeadline
     );
 
     /// @notice Event emitted when a Uniswap V3 LP token has been deposited
@@ -45,10 +49,12 @@ interface IUniswapV3Staker {
     /// @notice Event emitted when a Uniswap V3 LP token has been staked
     /// @param tokenId The unique identifier of an Uniswap V3 LP token
     /// @param liquidity The amount of liquidity staked
+    /// @param incentiveId The incentive in which the token is staking 
     event TokenStaked(uint256 tokenId, uint128 liquidity, bytes32 incentiveId);
 
     /// @notice Event emitted when a Uniswap V3 LP token has been unstaked
     /// @param tokenId The unique identifier of an Uniswap V3 LP token
+    /// @param incentiveId The incentive in which the token is staking
     event TokenUnstaked(uint256 tokenId, bytes32 incentiveId);
 
     /// @notice Event emitted when a reward token has been claimed

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -10,12 +10,13 @@ interface IUniswapV3Staker {
     /// @param claimDeadline Time after which LPs can no longer claim rewards (and incentiveCreator can end the incentive and receive unclaimed rewards)
     /// @param totalReward The total amount of reward tokens to be distributed
     event IncentiveCreated(
+        address creator,
         address indexed rewardToken,
         address indexed pool,
         uint32 startTime,
         uint32 endTime,
         uint32 claimDeadline,
-        uint128 indexed totalReward
+        uint128 totalReward
     );
 
     /// @notice Event emitted when a liquidity mining incentive has ended
@@ -24,6 +25,7 @@ interface IUniswapV3Staker {
     /// @param startTime The time when the incentive program begins
     /// @param endTime The time when rewards stop accruing
     event IncentiveEnded(
+        address creator,
         address indexed rewardToken,
         address indexed pool,
         uint32 startTime,

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -33,7 +33,7 @@ interface IUniswapV3Staker {
         address indexed pool,
         uint32 startTime,
         uint32 endTime,
-        uint43 claimDeadline
+        uint32 claimDeadline
     );
 
     /// @notice Event emitted when a Uniswap V3 LP token has been deposited
@@ -49,7 +49,7 @@ interface IUniswapV3Staker {
     /// @notice Event emitted when a Uniswap V3 LP token has been staked
     /// @param tokenId The unique identifier of an Uniswap V3 LP token
     /// @param liquidity The amount of liquidity staked
-    /// @param incentiveId The incentive in which the token is staking 
+    /// @param incentiveId The incentive in which the token is staking
     event TokenStaked(uint256 tokenId, uint128 liquidity, bytes32 incentiveId);
 
     /// @notice Event emitted when a Uniswap V3 LP token has been unstaked

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -43,11 +43,11 @@ interface IUniswapV3Staker {
     /// @notice Event emitted when a Uniswap V3 LP token has been staked
     /// @param tokenId The unique identifier of an Uniswap V3 LP token
     /// @param liquidity The amount of liquidity staked
-    event TokenStaked(uint256 tokenId, uint128 liquidity);
+    event TokenStaked(uint256 tokenId, uint128 liquidity, bytes32 incentiveId);
 
     /// @notice Event emitted when a Uniswap V3 LP token has been unstaked
     /// @param tokenId The unique identifier of an Uniswap V3 LP token
-    event TokenUnstaked(uint256 tokenId);
+    event TokenUnstaked(uint256 tokenId, bytes32 incentiveId);
 
     /// @notice Event emitted when a reward token has been claimed
     /// @param to The address where claimed rewards were sent to

--- a/test/UniswapV3Staker.unit.spec.ts
+++ b/test/UniswapV3Staker.unit.spec.ts
@@ -161,6 +161,7 @@ describe('UniswapV3Staker.unit', async () => {
         await expect(subject({ startTime, endTime, claimDeadline }))
           .to.emit(context.staker, 'IncentiveCreated')
           .withArgs(
+            incentiveCreator.address,
             context.rewardToken.address,
             context.pool01,
             startTime,
@@ -273,6 +274,7 @@ describe('UniswapV3Staker.unit', async () => {
         await expect(subject({}))
           .to.emit(context.staker, 'IncentiveEnded')
           .withArgs(
+            incentiveCreator.address,
             context.rewardToken.address,
             context.pool01,
             timestamps.startTime,

--- a/test/UniswapV3Staker.unit.spec.ts
+++ b/test/UniswapV3Staker.unit.spec.ts
@@ -278,7 +278,8 @@ describe('UniswapV3Staker.unit', async () => {
             context.rewardToken.address,
             context.pool01,
             timestamps.startTime,
-            timestamps.endTime
+            timestamps.endTime,
+            timestamps.claimDeadline
           )
       })
 

--- a/test/UniswapV3Staker.unit.spec.ts
+++ b/test/UniswapV3Staker.unit.spec.ts
@@ -429,6 +429,12 @@ describe('UniswapV3Staker.unit', async () => {
           await expect(subject(tokenId, recipient)).to.be.reverted
         })
 
+        it('deletes deposit upon withdrawal', async () => {
+          expect((await context.staker.deposits(tokenId)).owner).to.equal(lpUser0.address)
+          await subject(tokenId, recipient)
+          expect((await context.staker.deposits(tokenId)).owner).to.equal(constants.AddressZero)
+        })
+
         it('has gas cost', async () =>
           await snapshotGasCost(subject(tokenId, recipient)))
       })

--- a/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
@@ -6,12 +6,12 @@ exports[`UniswapV3Staker.unit #createIncentive works and has gas cost 1`] = `825
 
 exports[`UniswapV3Staker.unit #endIncentive works and has gas cost 1`] = `38404`;
 
-exports[`UniswapV3Staker.unit #onERC721Received on successful transfer with staking data has gas cost 1`] = `201730`;
+exports[`UniswapV3Staker.unit #onERC721Received on successful transfer with staking data has gas cost 1`] = `202016`;
 
 exports[`UniswapV3Staker.unit Deposit/Withdraw #depositToken works and has gas cost 1`] = `96861`;
 
 exports[`UniswapV3Staker.unit Deposit/Withdraw #withdrawToken works and has gas cost 1`] = `86114`;
 
-exports[`UniswapV3Staker.unit Stake/Unstake #stakeToken works and has gas cost 1`] = `122531`;
+exports[`UniswapV3Staker.unit Stake/Unstake #stakeToken works and has gas cost 1`] = `122817`;
 
-exports[`UniswapV3Staker.unit Stake/Unstake #unstakeToken works and has gas cost 1`] = `105324`;
+exports[`UniswapV3Staker.unit Stake/Unstake #unstakeToken works and has gas cost 1`] = `105601`;

--- a/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`UniswapV3Staker.unit #claimReward has gas cost 1`] = `46949`;
 
 exports[`UniswapV3Staker.unit #createIncentive works and has gas cost 1`] = `82751`;
 
-exports[`UniswapV3Staker.unit #endIncentive works and has gas cost 1`] = `38548`;
+exports[`UniswapV3Staker.unit #endIncentive works and has gas cost 1`] = `38695`;
 
 exports[`UniswapV3Staker.unit #onERC721Received on successful transfer with staking data has gas cost 1`] = `202016`;
 

--- a/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`UniswapV3Staker.unit #claimReward has gas cost 1`] = `46949`;
 
-exports[`UniswapV3Staker.unit #createIncentive works and has gas cost 1`] = `82557`;
+exports[`UniswapV3Staker.unit #createIncentive works and has gas cost 1`] = `82751`;
 
-exports[`UniswapV3Staker.unit #endIncentive works and has gas cost 1`] = `38404`;
+exports[`UniswapV3Staker.unit #endIncentive works and has gas cost 1`] = `38548`;
 
 exports[`UniswapV3Staker.unit #onERC721Received on successful transfer with staking data has gas cost 1`] = `202016`;
 

--- a/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`UniswapV3Staker.unit #onERC721Received on successful transfer with stak
 
 exports[`UniswapV3Staker.unit Deposit/Withdraw #depositToken works and has gas cost 1`] = `96861`;
 
-exports[`UniswapV3Staker.unit Deposit/Withdraw #withdrawToken works and has gas cost 1`] = `86114`;
+exports[`UniswapV3Staker.unit Deposit/Withdraw #withdrawToken works and has gas cost 1`] = `74198`;
 
 exports[`UniswapV3Staker.unit Stake/Unstake #stakeToken works and has gas cost 1`] = `122817`;
 


### PR DESCRIPTION
Include all params used to hash incentiveId in incentive related events. Or else could, incentives with similar params (minus the ones omitted) could get mixed up for each other.

closes https://github.com/omarish/uniswap-v3-staker/issues/87