### PR TITLE
update _stakeToken to call _getPositionDetails once

### DIFF
--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -295,8 +295,12 @@ contract UniswapV3Staker is
         require(params.startTime <= block.timestamp, 'incentive not started');
         require(params.endTime > block.timestamp, 'incentive ended');
 
-        (address poolAddress, int24 tickLower, int24 tickUpper, ) =
-            _getPositionDetails(params.tokenId);
+        (
+            address poolAddress,
+            int24 tickLower,
+            int24 tickUpper,
+            uint128 liquidity
+        ) = _getPositionDetails(params.tokenId);
 
         bytes32 incentiveId =
             IncentiveHelper.getIncentiveId(
@@ -322,7 +326,7 @@ contract UniswapV3Staker is
                 tickLower,
                 tickUpper
             );
-        (, , , uint128 liquidity) = _getPositionDetails(params.tokenId);
+
         stakes[params.tokenId][incentiveId] = Stake(
             secondsPerLiquidityInsideX128,
             liquidity,

--- a/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniswapV3Staker.unit #onERC721Received on successful transfer with staking data has gas cost 1`] = `201927`;
+exports[`UniswapV3Staker.unit #onERC721Received on successful transfer with staking data has gas cost 1`] = `196382`;
 
 exports[`UniswapV3Staker.unit Deposits #depositToken works and has gas cost 1`] = `96839`;
 
@@ -12,6 +12,6 @@ exports[`UniswapV3Staker.unit Incentives #endIncentive works and has gas cost 1`
 
 exports[`UniswapV3Staker.unit Stakes #claimReward has gas cost 1`] = `46949`;
 
-exports[`UniswapV3Staker.unit Stakes #stakeToken works and has gas cost 1`] = `122728`;
+exports[`UniswapV3Staker.unit Stakes #stakeToken works and has gas cost 1`] = `117184`;
 
 exports[`UniswapV3Staker.unit Stakes #unstakeToken works and has gas cost 1`] = `105634`;


### PR DESCRIPTION
I couldn't figure a reason this was split in to two calls. Tiny efficiency gain.

⛽️🏌️