### PR TITLE
createIncentive requires `startTime` has not passed 

### DIFF
--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -55,7 +55,8 @@ contract UniswapV3Staker is IUniswapV3Staker, IERC721Receiver, Multicall {
     {
         require(
             params.startTime < params.endTime &&
-                params.endTime < params.claimDeadline,
+                params.endTime < params.claimDeadline &&
+                block.timestamp < params.startTime,
             'timestamps invalid'
         );
 

--- a/test/UniswapV3Staker.unit.spec.ts
+++ b/test/UniswapV3Staker.unit.spec.ts
@@ -109,7 +109,7 @@ describe('UniswapV3Staker.unit', async () => {
   })
 
   describe('Incentives', () => {
-    describe('#createIncentive', async () => {
+    describe('#createIncentive', () => {
       let subject: (
         params: Partial<ContractParams.CreateIncentive>
       ) => Promise<any>
@@ -144,7 +144,7 @@ describe('UniswapV3Staker.unit', async () => {
         }
       })
 
-      describe('works and', async () => {
+      describe('works and', () => {
         it('transfers the right amount of rewardToken', async () => {
           const balanceBefore = await context.rewardToken.balanceOf(
             context.staker.address
@@ -200,7 +200,7 @@ describe('UniswapV3Staker.unit', async () => {
 
       describe('fails when', () => {
         it('there is already has an incentive with those params', async () => {
-          const params = makeTimestamps((await blockTimestamp()) + 10)
+          const params = makeTimestamps(await blockTimestamp())
           expect(await subject(params)).to.emit(
             context.staker,
             'IncentiveCreated'
@@ -242,7 +242,7 @@ describe('UniswapV3Staker.unit', async () => {
           })
 
           it('claim deadline is before end time', async () => {
-            const params = makeTimestamps((await blockTimestamp()) + 10)
+            const params = makeTimestamps(await blockTimestamp())
             params.endTime = params.claimDeadline + 100
             await expect(subject(params)).to.be.revertedWith(
               ERR_TIMESTAMPS_INVALID
@@ -250,7 +250,7 @@ describe('UniswapV3Staker.unit', async () => {
           })
 
           it('claim deadline is before start time', async () => {
-            const params = makeTimestamps((await blockTimestamp()) + 10)
+            const params = makeTimestamps(await blockTimestamp())
             params.claimDeadline = params.startTime - 10
             await expect(subject(params)).to.be.revertedWith(
               ERR_TIMESTAMPS_INVALID
@@ -258,7 +258,7 @@ describe('UniswapV3Staker.unit', async () => {
           })
 
           it('end time is before start time', async () => {
-            const params = makeTimestamps((await blockTimestamp()) + 10)
+            const params = makeTimestamps(await blockTimestamp())
             params.endTime = params.startTime - 10
             await expect(subject(params)).to.be.revertedWith(
               ERR_TIMESTAMPS_INVALID
@@ -277,7 +277,7 @@ describe('UniswapV3Staker.unit', async () => {
                 rewardToken: constants.AddressZero,
                 pool: context.pool01,
                 totalReward,
-                ...makeTimestamps(now + 100, 1_000, 2_000),
+                ...makeTimestamps(now, 1_000, 2_000),
               })
             ).to.be.revertedWith(ERR_REWARD_INVALID)
           })
@@ -290,7 +290,7 @@ describe('UniswapV3Staker.unit', async () => {
                 rewardToken: context.rewardToken.address,
                 pool: context.pool01,
                 totalReward: BNe18(0),
-                ...makeTimestamps(now + 100, 1_000, 2_000),
+                ...makeTimestamps(now, 1_000, 2_000),
               })
             ).to.be.revertedWith(ERR_REWARD_INVALID)
           })
@@ -509,14 +509,15 @@ describe('UniswapV3Staker.unit', async () => {
         })
 
         it('number of stakes is not 0', async () => {
+          const timestamps = makeTimestamps(await blockTimestamp())
           const incentiveParams: HelperTypes.CreateIncentive.Args = {
             rewardToken: context.rewardToken,
             totalReward,
             poolAddress: context.poolObj.address,
-            ...makeTimestamps(await blockTimestamp()),
+            ...timestamps,
           }
           const incentive = await helpers.createIncentiveFlow(incentiveParams)
-
+          await Time.setAndMine(timestamps.startTime + 1)
           await context.staker.connect(lpUser0).stakeToken({
             ...incentive,
             rewardToken: incentive.rewardToken.address,
@@ -781,7 +782,7 @@ describe('UniswapV3Staker.unit', async () => {
           poolAddress: context.poolObj.address,
           ...timestamps,
         })
-
+        await Time.setAndMine(timestamps.startTime + 1)
         const { tokenId } = await helpers.mintDepositStakeFlow({
           lp: lpUser0,
           tokensToStake,
@@ -887,6 +888,7 @@ describe('UniswapV3Staker.unit', async () => {
 
         await context.staker.connect(lpUser0).depositToken(tokenId)
 
+        await Time.setAndMine(timestamps.startTime + 1)
         await context.staker.connect(lpUser0).stakeToken({
           creator: incentiveCreator.address,
           rewardToken: context.rewardToken.address,
@@ -905,7 +907,7 @@ describe('UniswapV3Staker.unit', async () => {
           })
       })
 
-      describe('works and', async () => {
+      describe('works and', () => {
         it('decrements numberOfStakes by 1', async () => {
           const { numberOfStakes: stakesPre } = await context.staker.deposits(
             tokenId
@@ -1227,7 +1229,7 @@ describe('UniswapV3Staker.unit', async () => {
             pool: context.pool01,
             rewardToken: context.rewardToken.address,
             totalReward,
-            ...makeTimestamps(currentTime),
+            ...makeTimestamps(currentTime + 100),
           },
         ]
       )

--- a/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
+++ b/test/__snapshots__/UniswapV3Staker.unit.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`UniswapV3Staker.unit Deposits #depositToken works and has gas cost 1`] 
 
 exports[`UniswapV3Staker.unit Deposits #withdrawToken works and has gas cost 1`] = `74092`;
 
-exports[`UniswapV3Staker.unit Incentives #createIncentive works and has gas cost 1`] = `82666`;
+exports[`UniswapV3Staker.unit Incentives #createIncentive works and has gas cost 1`] = `82711`;
 
 exports[`UniswapV3Staker.unit Incentives #endIncentive works and has gas cost 1`] = `36384`;
 

--- a/test/shared/index.ts
+++ b/test/shared/index.ts
@@ -151,8 +151,12 @@ export const erc20Wrap = async (x: string | TestERC20): Promise<TestERC20> => {
   return x
 }
 
-export const makeTimestamps = (n: number) => ({
+export const makeTimestamps = (
+  n: number,
+  duration: number = 1_000,
+  claimDuration: number = 1_000
+) => ({
   startTime: n,
-  endTime: n + 1_000,
-  claimDeadline: n + 2_000,
+  endTime: n + duration,
+  claimDeadline: n + duration + claimDuration,
 })

--- a/test/shared/index.ts
+++ b/test/shared/index.ts
@@ -156,7 +156,7 @@ export const makeTimestamps = (
   duration: number = 1_000,
   claimDuration: number = 1_000
 ) => ({
-  startTime: n,
-  endTime: n + duration,
-  claimDeadline: n + duration + claimDuration,
+  startTime: n + 100,
+  endTime: n + 100 + duration,
+  claimDeadline: n + 100 + duration + claimDuration,
 })

--- a/test/shared/time.ts
+++ b/test/shared/time.ts
@@ -4,7 +4,11 @@ import { log } from './logging'
 
 type TimeSetterFunction = (timestamp: number) => Promise<any>
 
-type TimeSetters = { set: TimeSetterFunction; step: TimeSetterFunction }
+type TimeSetters = {
+  set: TimeSetterFunction
+  step: TimeSetterFunction
+  setAndMine: TimeSetterFunction
+}
 
 export const createTimeMachine = (provider: MockProvider): TimeSetters => {
   return {
@@ -19,6 +23,12 @@ export const createTimeMachine = (provider: MockProvider): TimeSetters => {
       log.debug(`🕒 increaseTime(${interval})`)
       await provider.send('evm_increaseTime', [interval])
       await ethers.provider.send('evm_increaseTime', [interval])
+    },
+
+    setAndMine: async (timestamp: number) => {
+      await provider.send('evm_increaseTime', [timestamp])
+      await ethers.provider.send('evm_increaseTime', [timestamp])
+      await provider.send('evm_mine', [])
     },
   }
 }

--- a/test/shared/time.ts
+++ b/test/shared/time.ts
@@ -26,8 +26,8 @@ export const createTimeMachine = (provider: MockProvider): TimeSetters => {
     },
 
     setAndMine: async (timestamp: number) => {
-      await provider.send('evm_increaseTime', [timestamp])
-      await ethers.provider.send('evm_increaseTime', [timestamp])
+      await provider.send('evm_setNextBlockTimestamp', [timestamp])
+      await ethers.provider.send('evm_setNextBlockTimestamp', [timestamp])
       await provider.send('evm_mine', [])
     },
   }


### PR DESCRIPTION
Closes #116 

- Adds failing test
- Fixes time test
- Fixes incentive timing tests
